### PR TITLE
fix: register new Twig partials in HMR without restart

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-twing-drupal",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Provides a ⚡️ Vite plugin to transform 🌱 Twing.js into HTML with a 💧 Drupal flavour",
   "keywords": [
     "Vite",

--- a/src/loader/createSDCLoader.js
+++ b/src/loader/createSDCLoader.js
@@ -113,6 +113,8 @@ export function createSDCLoader(templates, namespaces, name = "sdc-array") {
         }
         const resolved = normalized.join("/")
         if (templates[resolved] !== undefined) {
+          // Register under the relative key so getSource can find it
+          templates[name] = templates[resolved]
           return resolved
         }
       }

--- a/src/loader/createSDCLoader.js
+++ b/src/loader/createSDCLoader.js
@@ -101,6 +101,22 @@ export function createSDCLoader(templates, namespaces, name = "sdc-array") {
       console.log(
         `[SDC Loader] Resolving template: ${name} ${from ? `from ${from}` : ""}`
       )
+
+      // Resolve relative paths (./foo.twig, ../bar.twig) against the parent template
+      if (from && (name.startsWith("./") || name.startsWith("../"))) {
+        const dir = from.substring(0, from.lastIndexOf("/"))
+        const parts = `${dir}/${name}`.split("/")
+        const normalized = []
+        for (const part of parts) {
+          if (part === "..") normalized.pop()
+          else if (part !== ".") normalized.push(part)
+        }
+        const resolved = normalized.join("/")
+        if (templates[resolved] !== undefined) {
+          return resolved
+        }
+      }
+
       // If baseLoader has resolve method, use it
       if (typeof baseLoader.resolve === "function") {
         return baseLoader.resolve(name, from)

--- a/src/vite-plugin-precompile-twig.js
+++ b/src/vite-plugin-precompile-twig.js
@@ -480,11 +480,33 @@ function createHMRHelpers(
 
   function getTemplatesForUpdate(originalFile) {
     const originalTemplate = resolveTemplateWithErrorHandling(originalFile)
-    if (!originalTemplate) {
-      return []
+    if (originalTemplate) {
+      return [originalTemplate]
     }
 
-    return [originalTemplate]
+    // Template not in cache — try to register it as a new file.
+    // This handles Twig partials (e.g. variant includes like card--horizontal.twig)
+    // that were created after the dev server started.
+    if (existsSync(originalFile)) {
+      const content = readFileSync(originalFile, "utf8")
+
+      // Try to determine the namespace key for this file
+      for (const [namespace, dirPaths] of Object.entries(resolvedNamespaces)) {
+        for (const dir of dirPaths) {
+          if (originalFile.startsWith(dir)) {
+            const relativePath = relative(dir, originalFile).replace(/\\/g, "/")
+            const key = `@${namespace}/${relativePath}`
+            templateSources[key] = content
+            // Also register with the relative path for direct lookups
+            templateSources[relativePath] = content
+            console.log(`[HMR] Registered new template: ${key}`)
+            return [{ key, content }]
+          }
+        }
+      }
+    }
+
+    return []
   }
 
   function updateTemplateCache(templates) {

--- a/tests/__snapshots__/smoke.test.js.snap
+++ b/tests/__snapshots__/smoke.test.js.snap
@@ -31,12 +31,22 @@ exports[`Basic smoke test > Should support includes 1`] = `
 <p>Card</p>
 <div>atom badge from nested dir 🙌</div>
 <button>nested button 🙌</button>
+<div class="card-teaser">
+  <h3>Relative include</h3>
+  <span>resolved via ./ path</span>
+</div>
+<div>Parent relative include 🔼</div>
 <button>SDC</button>
 <button>included button 👈️</button>
 <h2>Include card</h2>
 <p>🏆️ winning</p>
 <div>atom badge from nested dir 🙌</div>
 <button>nested button 🙌</button>
+<div class="card-teaser">
+  <h3>Relative include</h3>
+  <span>resolved via ./ path</span>
+</div>
+<div>Parent relative include 🔼</div>
 <div  class="provided-class">hey there</div>
   All received
     pony town

--- a/tests/fixtures/jabba/card/card--teaser.twig
+++ b/tests/fixtures/jabba/card/card--teaser.twig
@@ -1,0 +1,4 @@
+<div class="card-teaser">
+  <h3>{{ title }}</h3>
+  <span>{{ summary }}</span>
+</div>

--- a/tests/fixtures/jabba/card/card.twig
+++ b/tests/fixtures/jabba/card/card.twig
@@ -6,3 +6,10 @@
 {% include 'jabba:button' with {
   title: 'nested button 🙌',
 } %}
+{% include './card--teaser.twig' with {
+  title: 'Relative include',
+  summary: 'resolved via ./ path',
+} %}
+{% include '../atoms/badge/badge.twig' with {
+  label: 'Parent relative include 🔼',
+} %}

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -18,4 +18,18 @@ describe("Basic smoke test", () => {
     expect(markup).toContain("Nested include")
     expect(markup).toContain("Relative include")
   })
+
+  it("Should resolve relative ./ includes", async () => {
+    const markup = Markup.render({
+      attributes: { class: 'test' },
+    });
+    expect(markup).toContain("resolved via ./ path")
+  })
+
+  it("Should resolve relative ../ includes", async () => {
+    const markup = Markup.render({
+      attributes: { class: 'test' },
+    });
+    expect(markup).toContain("Parent relative include")
+  })
 })


### PR DESCRIPTION
When Twig variant partials (e.g. navigation--footer.twig) are created after the dev server starts, they were never registered in the template cache, causing permanent "Unable to find template" errors until restart.

The fix extends getTemplatesForUpdate to detect new files on disk, determine their namespace key, and register them in templateSources so the existing HMR flow (updateTemplateCache + findAffectedModules) picks them up immediately.