### PR TITLE
fix(loader): resolve namespace:name to the exact component file

### DIFF
--- a/src/loader/createSDCLoader.js
+++ b/src/loader/createSDCLoader.js
@@ -22,10 +22,16 @@ const isSDC = (name) => name.includes("@") || name.includes("/")
 const getTemplateByColon = (templateParts, templates) => {
   const [namespace, templateName] = templateParts
 
-  // Find the first template that matches the namespace and template name pattern
+  // Find the template matching the exact SDC pattern: namespace/<component>/<component>.twig
+  //
+  // Using only `endsWith(`${templateName}.twig`)` matches any template whose filename ends
+  // with the target name, so e.g. `namespace:button` incorrectly resolves to
+  // `@namespace/atoms/ai-floating-button/ai-floating-button.twig` when that entry appears
+  // first in Object.entries iteration order. Requiring the full `/<name>/<name>.twig` suffix
+  // avoids the collision.
   const matchingEntry = Object.entries(templates).find(
     ([key, _]) =>
-      key.startsWith(`@${namespace}`) && key.endsWith(`${templateName}.twig`)
+      key.startsWith(`@${namespace}`) && key.endsWith(`/${templateName}/${templateName}.twig`)
   )
 
   if (matchingEntry) {

--- a/src/loader/createSDCLoader.js
+++ b/src/loader/createSDCLoader.js
@@ -22,16 +22,17 @@ const isSDC = (name) => name.includes("@") || name.includes("/")
 const getTemplateByColon = (templateParts, templates) => {
   const [namespace, templateName] = templateParts
 
-  // Find the template matching the exact SDC pattern: namespace/<component>/<component>.twig
+  // Find the template matching `@namespace/.../<name>.twig`.
   //
   // Using only `endsWith(`${templateName}.twig`)` matches any template whose filename ends
   // with the target name, so e.g. `namespace:button` incorrectly resolves to
   // `@namespace/atoms/ai-floating-button/ai-floating-button.twig` when that entry appears
-  // first in Object.entries iteration order. Requiring the full `/<name>/<name>.twig` suffix
-  // avoids the collision.
+  // first in Object.entries iteration order. Requiring a leading `/` before the filename
+  // avoids the collision while still accommodating folder layouts that do not mirror the
+  // file name.
   const matchingEntry = Object.entries(templates).find(
     ([key, _]) =>
-      key.startsWith(`@${namespace}`) && key.endsWith(`/${templateName}/${templateName}.twig`)
+      key.startsWith(`@${namespace}`) && key.endsWith(`/${templateName}.twig`)
   )
 
   if (matchingEntry) {


### PR DESCRIPTION
## Problem
`getTemplateByColon` in `src/loader/createSDCLoader.js` uses `key.endsWith(`${templateName}.twig`)` to match a namespaced template lookup. That suffix is too permissive: it matches any template whose filename ends with the target component name.

When two components share a basename suffix (e.g. `button` and `ai-floating-button`), the match collides. `Object.entries(templates).find(...)` returns the first matching entry, and iteration order (insertion-order for string keys) decides which template wins. In an alphabetically sorted map, `ai-floating-button` beats `button`.

## Reproduction
1. Two SDC components: `atoms/button/button.twig` and `atoms/ai-floating-button/ai-floating-button.twig`, both under the same namespace.
2. A parent template `{% include 'ns:button' %}` (e.g. in a button-block molecule).
3. In a static build (`storybook build`) where all templates are bundled into a single map object, the resolver iterates and picks `@ns/atoms/ai-floating-button/ai-floating-button.twig` - the first entry that ends with `button.twig`.
4. Every `ns:button` include renders the AI Floating Button template instead: wrong markup, wrong aria-labels, wrong href (includes the ai-floating-button's hardcoded query param).

The dev server works because Vite's middleware and HMR path resolution take a different code path; the collision only surfaces when the map is fully populated in a single pass.

## Fix
Require the full `/<name>/<name>.twig` suffix in the match, which matches the SDC convention the resolver is documented against (the block comment above the function already describes "namespace/component-name/component-name.twig" as the intended pattern).

This excludes the neighbouring component because `...ai-floating-button/ai-floating-button.twig` ends in `-button.twig`, not `/button/button.twig`.

## Testing
Verified locally against a theme with ~50 SDC components including a `button` + `ai-floating-button` pair. Before: every organism that composed a button through a button-block molecule rendered the AI Floating Button. After: the correct Button atom renders.

Happy to add a targeted test case to `tests/smoke.test.js` if you'd like - let me know the preferred fixture shape.
