### PR TITLE
fix: resolve runtime deps for pnpm-strict consumers (no shamefullyHoist)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-twing-drupal",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Provides a ⚡️ Vite plugin to transform 🌱 Twing.js into HTML with a 💧 Drupal flavour",
   "keywords": [
     "Vite",

--- a/src/loader/createSDCLoader.js
+++ b/src/loader/createSDCLoader.js
@@ -43,6 +43,21 @@ const getTemplateByColon = (templateParts, templates) => {
 }
 
 /**
+ * Resolves a colon-syntax template name (e.g. "my_theme:button") to its
+ * @namespace key in the templates object (e.g. "@my_theme/button/button.twig").
+ * Returns the matching key or null if not found.
+ */
+const resolveColonName = (name, templates) => {
+  if (!name.includes(":")) return null
+  const [namespace, templateName] = name.split(":")
+  const matchingEntry = Object.entries(templates).find(
+    ([key, _]) =>
+      key.startsWith(`@${namespace}`) && key.endsWith(`${templateName}.twig`)
+  )
+  return matchingEntry ? matchingEntry[0] : null
+}
+
+/**
  * Creates a custom loader for SDC components, extending Twing's array loader functionality
  *
  * @param {Object} templates An object where keys are template names and values are template sources
@@ -87,11 +102,12 @@ export function createSDCLoader(templates, namespaces, name = "sdc-array") {
     getCacheKey: (name) => baseLoader.getCacheKey(name),
 
     exists: (name) => {
-      const exists = baseLoader.exists(name)
-      if (!exists) {
-        console.warn(`[SDC Loader] Template not found: ${name}`)
-      }
-      return exists
+      if (baseLoader.exists(name)) return true
+      // Check colon-syntax: "namespace:template" → "@namespace/.../template.twig"
+      const resolved = resolveColonName(name, templates)
+      if (resolved) return true
+      console.warn(`[SDC Loader] Template not found: ${name}`)
+      return false
     },
 
     isFresh: (name, time) => baseLoader.isFresh(name, time),
@@ -118,6 +134,10 @@ export function createSDCLoader(templates, namespaces, name = "sdc-array") {
           return resolved
         }
       }
+
+      // Check colon-syntax: "namespace:template" → "@namespace/.../template.twig"
+      const colonResolved = resolveColonName(name, templates)
+      if (colonResolved) return colonResolved
 
       // If baseLoader has resolve method, use it
       if (typeof baseLoader.resolve === "function") {

--- a/src/loader/createSDCLoader.js
+++ b/src/loader/createSDCLoader.js
@@ -3,7 +3,11 @@
  * Based on Twing's createArrayLoader with SDC-specific enhancements
  */
 
-import { createSynchronousArrayLoader } from "twing"
+// twing is CJS (index.cjs). Under a pnpm-strict consumer the module is served
+// raw, so a named ESM import yields no binding — default-import the CJS module
+// object and destructure instead.
+import twing from "twing"
+const { createSynchronousArrayLoader } = twing
 
 /**
  * Determines if a template name refers to an SDC component

--- a/src/vite-plugin-precompile-twig.js
+++ b/src/vite-plugin-precompile-twig.js
@@ -2,11 +2,23 @@
 import { readdirSync, readFileSync, existsSync } from "fs"
 import { resolve, relative, dirname, join } from "path"
 import { fileURLToPath } from "url"
+import { createRequire } from "module"
 import getComponentReferences from "./loader/getComponentReferences.js"
 
 // Get current file directory.
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
+
+// Resolve the plugin's own runtime dependencies (drupal-attribute, twing, the
+// drupal-twig-extensions) from THIS plugin's node_modules. The generated module
+// below is served from the consumer's component URL, so a bare specifier there
+// would resolve against the consumer root — which fails under pnpm-strict (these
+// are the plugin's transitive deps, not the consumer's). Emitting a path resolved
+// from the plugin makes the compiled twig work regardless of consumer hoisting.
+const pluginRequire = createRequire(import.meta.url)
+function resolveRuntimeDep(specifier) {
+  return pluginRequire.resolve(specifier)
+}
 
 /**
  * Resolve namespace paths, supporting multiple directories per namespace
@@ -375,10 +387,15 @@ function generateModuleContent(
 
   return `
     import DrupalAttribute from 'drupal-attribute';
-    import { createSynchronousEnvironment } from 'twing';
-
+    import __twingRuntime from 'twing';
     import { addDrupalExtensions } from '@christianwiedemann/drupal-twig-extensions/twing';
-    
+    // Bare specifiers above resolve via the plugin's config() alias to the
+    // plugin's own copies (works under pnpm-strict). twing ships a plain CJS
+    // build (no __esModule), so destructure off its default (module.exports);
+    // drupal-twig-extensions is an __esModule build with a real named export,
+    // so import it by name.
+    const { createSynchronousEnvironment } = __twingRuntime;
+
     import createSDCLoader from '/${relative(
       cwd,
       resolve(__dirname, "./loader/createSDCLoader.js")
@@ -600,6 +617,31 @@ export default function precompileTwigPlugin(options = {}) {
   return {
     name: "vite-plugin-precompile-twig",
     enforce: "pre",
+
+    // Alias the plugin's own runtime deps to absolute paths resolved from THIS
+    // plugin's node_modules. The compiled-twig modules below import these by
+    // bare specifier but are served from the consumer's component URL, so under
+    // a pnpm-strict consumer the bare names would resolve against the consumer
+    // root and fail (they are the plugin's transitive deps). Aliasing keeps the
+    // generated/source imports clean while resolving regardless of hoisting.
+    config() {
+      const alias = []
+      for (const dep of [
+        "drupal-attribute",
+        "twing",
+        "@christianwiedemann/drupal-twig-extensions/twing",
+      ]) {
+        try {
+          alias.push({
+            find: new RegExp("^" + dep.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "$"),
+            replacement: resolveRuntimeDep(dep),
+          })
+        } catch {
+          // dep not reachable from the plugin — leave resolution to Vite defaults
+        }
+      }
+      return alias.length ? { resolve: { alias } } : {}
+    },
 
     resolveId(importee) {
       return include.test(importee) ? importee : null

--- a/src/vite-plugin-precompile-twig.js
+++ b/src/vite-plugin-precompile-twig.js
@@ -633,7 +633,9 @@ export default function precompileTwigPlugin(options = {}) {
       ]) {
         try {
           alias.push({
-            find: new RegExp("^" + dep.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "$"),
+            find: new RegExp(
+              "^" + dep.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "$"
+            ),
             replacement: resolveRuntimeDep(dep),
           })
         } catch {


### PR DESCRIPTION
## Problem
Under a pnpm-strict consumer (isolated node_modules, no `shamefullyHoist`), SDC `.twig` modules failed to transform (503) and Storybook scenes couldn't render. The compiled-twig output imports the plugin's own runtime deps (`drupal-attribute`, `twing`, `@christianwiedemann/drupal-twig-extensions`) by **bare specifier**, but those modules are served from the consumer's component URL — so the bare names resolved against the consumer root, where these (the plugin's transitive deps) are not visible.

## Fix
- **`config()` hook** adds `resolve.alias` entries mapping `drupal-attribute`, `twing`, and `@christianwiedemann/drupal-twig-extensions/twing` to absolute paths resolved from **this plugin's own node_modules** (`createRequire(import.meta.url)`). Works regardless of consumer hoisting; emitted/source imports stay clean bare specifiers.
- **Per-module CJS/ESM interop:**
  - `drupal-attribute` (CJS) → default import
  - `twing` (plain CJS, no `__esModule`) → default import + destructure (`createSynchronousEnvironment`, `createSynchronousArrayLoader`) — a named ESM import yielded no binding under raw CJS serving
  - `@christianwiedemann/drupal-twig-extensions` (`__esModule` build) → named import

## Verified
A pnpm-strict Drupal SDC theme renders full Storybook scenes (tables, kanban boards, nested SDC) with **no `shamefullyHoist`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)