### PR TITLE
ci: switch to auto (PR-label-driven releases) (#15)

### DIFF
--- a/.autorc.json
+++ b/.autorc.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["npm", "released"],
+  "baseBranch": "main"
+}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,7 +1,9 @@
 name: validate
 permissions:
-  id-token: write  # Required for OIDC
-  contents: read
+  id-token: write # Required for OIDC / npm provenance
+  contents: write # auto needs to push the version commit + tag to main
+  issues: write # auto comments on released issues
+  pull-requests: write # auto comments on released PRs
 on:
   push:
     branches:
@@ -20,10 +22,10 @@ jobs:
         uses: styfle/cancel-workflow-action@0.9.0
 
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: ⎔ Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 
@@ -46,34 +48,30 @@ jobs:
     runs-on: ubuntu-latest
     if:
       ${{ github.repository == 'christianwiedemann/vite-plugin-twing-drupal' &&
-      contains('refs/heads/main',github.ref) && github.event_name == 'push' }}
+      github.ref == 'refs/heads/main' && github.event_name == 'push' }}
     steps:
       - name: 🛑 Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.0
 
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # auto needs full history + tags to compute the release
 
       - name: ⎔ Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 22
+          registry-url: 'https://registry.npmjs.org'
 
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1
         with:
           useLockFile: false
 
-      - name: 🏗 Run build script
-        run: npm run build
-
-      - name: 🚀 Release
-        uses: cycjimmy/semantic-release-action@v4
-        with:
-          semantic_version: 23
-          branches: |
-            [
-              'main'
-            ]
+      - name: 🚀 Release (auto, PR-label driven)
+        run: npx auto shipit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "update-snapshot": "vitest -u",
     "test:debug": "node --inspect-brk node_modules/.bin/vitest run",
     "pretest": "npm run-script build",
-    "semantic-release": "semantic-release"
+    "release": "auto shipit"
   },
   "repository": {
     "type": "git",
@@ -40,8 +40,8 @@
   },
   "devDependencies": {
     "prettier": "^3.0.3",
-    "semantic-release": "^24.2.7",
     "vite": "^6",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "auto": "^11.3.0"
   }
 }


### PR DESCRIPTION
Replace semantic-release with intuit/auto (same model as Storybook/designbook): release type comes from the merged PR labels (major/minor/patch/skip-release), not commit messages. Fixes the prior EGITNOPERMISSION failure by granting the release job contents/issues/pull-requests write. Publishes to npm via NPM_TOKEN.